### PR TITLE
Hiding amibiguous imports

### DIFF
--- a/Cudd/Convert.hs
+++ b/Cudd/Convert.hs
@@ -6,9 +6,9 @@ module Cudd.Convert (
     ) where
 
 import System.IO.Unsafe
-import Foreign.ForeignPtr
+import Foreign.ForeignPtr hiding (unsafeForeignPtrToPtr)
 import Foreign.ForeignPtr.Unsafe
-import Control.Monad.ST
+import Control.Monad.ST hiding (unsafeIOToST)
 import Control.Monad.ST.Unsafe
 
 import Cudd.Cudd as C

--- a/Cudd/Cudd.hs
+++ b/Cudd/Cudd.hs
@@ -88,7 +88,7 @@ import Foreign.Storable
 import Foreign.Ptr
 import Foreign.C.Types
 import Foreign.C.String
-import Foreign.ForeignPtr
+import Foreign.ForeignPtr hiding (unsafeForeignPtrToPtr)
 import Foreign.ForeignPtr.Unsafe
 import Foreign.Marshal.Alloc
 import Foreign.Marshal.Array

--- a/Cudd/ForeignHelpers.hs
+++ b/Cudd/ForeignHelpers.hs
@@ -6,7 +6,7 @@ module Cudd.ForeignHelpers (
     withStringArrayPtr
     ) where
 
-import Foreign
+import Foreign hiding (unsafeForeignPtrToPtr)
 import Foreign.C.String
 import Foreign.ForeignPtr.Unsafe
 

--- a/Cudd/GC.hs
+++ b/Cudd/GC.hs
@@ -17,7 +17,7 @@ import Foreign.C.Types
 import Foreign.C.String
 import Foreign.ForeignPtr
 import Control.Monad
-import Control.Monad.ST
+import Control.Monad.ST hiding (unsafeIOToST)
 import Control.Monad.ST.Unsafe
 
 import Cudd.Hook

--- a/Cudd/Hook.chs
+++ b/Cudd/Hook.chs
@@ -15,7 +15,7 @@ import Foreign.C.Types
 import Foreign.C.String
 import Foreign.ForeignPtr
 import Control.Monad
-import Control.Monad.ST
+import Control.Monad.ST hiding (unsafeIOToST)
 import Control.Monad.ST.Unsafe
 
 import Cudd.C

--- a/Cudd/Imperative.hs
+++ b/Cudd/Imperative.hs
@@ -106,10 +106,10 @@ module Cudd.Imperative (
     module Cudd.Common
     ) where
 
-import Foreign hiding (void)
+import Foreign hiding (void, unsafePerformIO)
 import Foreign.Ptr
 import Foreign.C.Types
-import Control.Monad.ST
+import Control.Monad.ST hiding (unsafeIOToST)
 import Control.Monad.ST.Unsafe
 import Control.Monad
 import Control.Monad.IO.Class

--- a/Cudd/MTR.chs
+++ b/Cudd/MTR.chs
@@ -24,7 +24,7 @@ import Foreign
 import Foreign.Ptr
 import Foreign.C.Types
 import Control.Monad
-import Control.Monad.ST
+import Control.Monad.ST hiding (unsafeIOToST)
 import Control.Monad.ST.Unsafe
 
 #include <stdio.h>

--- a/Cudd/Reorder.chs
+++ b/Cudd/Reorder.chs
@@ -42,7 +42,7 @@ import Foreign.C.Types
 import Foreign.C.String
 import Foreign.ForeignPtr
 import Control.Monad
-import Control.Monad.ST
+import Control.Monad.ST hiding (unsafeIOToST)
 import Control.Monad.ST.Unsafe
 
 import Cudd.C


### PR DESCRIPTION
(Sorry, I've skipped reading the part where you wanted an additional pull request)

I now rebased against the ghc7.6 but I think that `build-depends` in `cudd.cabal` needs to be fixed for master since base version 4.7 is still affected (http://hackage.haskell.org/package/base-4.7.0.0/docs/Foreign.html has all the identifiers).

So it should be `base >=4.8 && <4.9` for master and `base >=4.6 && <4.8`(?) for the ghc 7.6 branch (I'd guess).
