### PR TITLE
Include stdlib.h for using malloc() in c_sources/cuddwrap.c

### DIFF
--- a/c_sources/cuddwrap.c
+++ b/c_sources/cuddwrap.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <math.h>
 #include <assert.h>
 


### PR DESCRIPTION
I encountered the following error on macOS Big Sur.

```
haskell_cudd/c_sources/cuddwrap.c:46:20: error:
     error: implicitly declaring library function 'malloc' with type 'void *(unsigned long)' [-Werror,-Wimplicit-function-declaration]
        int **result = malloc(sizeof(int *)*num);
                       ^
   |
46 |     int **result = malloc(sizeof(int *)*num);
   |                    ^

haskell_cudd/c_sources/cuddwrap.c:46:20: error:
     note: include the header <stdlib.h> or explicitly provide a declaration for 'malloc'
   |
46 |     int **result = malloc(sizeof(int *)*num);
   |                    ^
1 error generated.
`gcc' failed in phase `C Compiler'. (Exit code: 1)
```