### PR TITLE
fix duplicated exports

### DIFF
--- a/Cudd/Imperative.hs
+++ b/Cudd/Imperative.hs
@@ -80,8 +80,6 @@ module Cudd.Imperative (
     setMaxCacheHard,
     readCacheSlots,
     readCacheUsedSlots,
-    cudd_unique_slots,
-    cudd_cache_slots,
     andLimit,
     readTree,
     newVarAtLevel,


### PR DESCRIPTION
This fixes the following warnings:

```
Cudd/Imperative.hs:109:5: warning: [-Wduplicate-exports]
    ‘cudd_unique_slots’ is exported by ‘module Cudd.Common’ and ‘cudd_unique_slots’
    |
109 |     module Cudd.Common
    |     ^^^^^^^^^^^^^^^^^^

Cudd/Imperative.hs:109:5: warning: [-Wduplicate-exports]
    ‘cudd_cache_slots’ is exported by ‘module Cudd.Common’ and ‘cudd_cache_slots’
    |
109 |     module Cudd.Common
    |     ^^^^^^^^^^^^^^^^^^
```