### PR TITLE
Use spaces instead of tab character

### DIFF
--- a/Cudd/C.hs
+++ b/Cudd/C.hs
@@ -113,61 +113,61 @@ data CDDNode
 data CDDGen
 
 foreign import ccall safe "Cudd_ReadOne_s"
-	c_cuddReadOne :: Ptr CDDManager -> IO (Ptr CDDNode)
+    c_cuddReadOne :: Ptr CDDManager -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_ReadLogicZero_s"
-	c_cuddReadLogicZero :: Ptr CDDManager -> IO (Ptr CDDNode)
+    c_cuddReadLogicZero :: Ptr CDDManager -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_ReadOne_withRef_s"
-	c_cuddReadOneWithRef :: Ptr CDDManager -> IO (Ptr CDDNode)
+    c_cuddReadOneWithRef :: Ptr CDDManager -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_ReadLogicZero_withRef_s"
-	c_cuddReadLogicZeroWithRef :: Ptr CDDManager -> IO (Ptr CDDNode)
+    c_cuddReadLogicZeroWithRef :: Ptr CDDManager -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_bddIthVar_s"
-	c_cuddBddIthVar :: Ptr CDDManager -> CInt -> IO (Ptr CDDNode)
+    c_cuddBddIthVar :: Ptr CDDManager -> CInt -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_bddAnd_s"
-	c_cuddBddAnd :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)
+    c_cuddBddAnd :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_bddOr_s"
-	c_cuddBddOr :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)
+    c_cuddBddOr :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_bddNand_s"
-	c_cuddBddNand :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)
+    c_cuddBddNand :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_bddNor_s"
-	c_cuddBddNor :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)
+    c_cuddBddNor :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_bddXor_s"
-	c_cuddBddXor :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)
+    c_cuddBddXor :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_bddXnor_s"
-	c_cuddBddXnor :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)
+    c_cuddBddXnor :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_Not_s"
-	c_cuddNot :: Ptr CDDNode -> IO (Ptr CDDNode)
+    c_cuddNot :: Ptr CDDNode -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_NotNoRef_s"
-	c_cuddNotNoRef :: Ptr CDDNode -> IO (Ptr CDDNode)
+    c_cuddNotNoRef :: Ptr CDDNode -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_bddIte_s"
     c_cuddBddIte :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_bddExistAbstract_s"
-	c_cuddBddExistAbstract :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)
+    c_cuddBddExistAbstract :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_bddUnivAbstract_s"
-	c_cuddBddUnivAbstract :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)
+    c_cuddBddUnivAbstract :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_IterDerefBdd"
-	c_cuddIterDerefBdd :: Ptr CDDManager -> Ptr CDDNode -> IO ()
+    c_cuddIterDerefBdd :: Ptr CDDManager -> Ptr CDDNode -> IO ()
 
 foreign import ccall safe "wrappedCuddRef"
-	cuddRef :: Ptr CDDNode -> IO ()
+    cuddRef :: Ptr CDDNode -> IO ()
 
 foreign import ccall safe "Cudd_Init"
-	c_cuddInit :: CInt -> CInt -> CInt -> CInt -> CInt -> IO (Ptr CDDManager)
+    c_cuddInit :: CInt -> CInt -> CInt -> CInt -> CInt -> IO (Ptr CDDManager)
 
 foreign import ccall safe "Cudd_ShuffleHeap"
     c_cuddShuffleHeap :: Ptr CDDManager -> Ptr CInt -> IO CInt
@@ -194,7 +194,7 @@ foreign import ccall safe "Cudd_Support_s"
     c_cuddSupport :: Ptr CDDManager -> Ptr CDDNode -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_SupportIndex"
-	c_cuddSupportIndex :: Ptr CDDManager -> Ptr CDDNode -> IO(Ptr CInt)
+    c_cuddSupportIndex :: Ptr CDDManager -> Ptr CDDNode -> IO(Ptr CInt)
 
 foreign import ccall safe "Cudd_SupportIndices"
     c_cuddSupportIndices :: Ptr CDDManager -> Ptr CDDNode -> Ptr (Ptr CInt) -> IO CInt
@@ -209,7 +209,7 @@ foreign import ccall safe "Cudd_BddToCubeArray"
     c_cuddBddToCubeArray :: Ptr CDDManager -> Ptr CDDNode -> Ptr CInt -> IO CInt
 
 foreign import ccall safe "Cudd_ReadSize"
-	c_cuddReadSize :: Ptr CDDManager -> IO CInt
+    c_cuddReadSize :: Ptr CDDManager -> IO CInt
 
 foreign import ccall safe "Cudd_bddCompose_s"
     c_cuddBddCompose :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> CInt -> IO (Ptr CDDNode)
@@ -227,7 +227,7 @@ foreign import ccall safe "Cudd_EquivDC"
     c_cuddEquivDC :: Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> Ptr CDDNode -> IO CInt
 
 foreign import ccall safe "Cudd_Xeqy_s"
-	c_cuddXeqy :: Ptr CDDManager -> CInt -> Ptr (Ptr CDDNode) -> Ptr (Ptr CDDNode) -> IO (Ptr CDDNode)
+    c_cuddXeqy :: Ptr CDDManager -> CInt -> Ptr (Ptr CDDNode) -> Ptr (Ptr CDDNode) -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_DebugCheck"
     c_cuddDebugCheck :: Ptr CDDManager -> IO CInt
@@ -236,7 +236,7 @@ foreign import ccall safe "Cudd_CheckKeys"
     c_cuddCheckKeys :: Ptr CDDManager -> IO CInt
 
 foreign import ccall safe "Cudd_bddPickOneMinterm_s"
-	c_cuddBddPickOneMinterm :: Ptr CDDManager -> Ptr CDDNode -> Ptr (Ptr CDDNode) -> CInt -> IO (Ptr CDDNode)
+    c_cuddBddPickOneMinterm :: Ptr CDDManager -> Ptr CDDNode -> Ptr (Ptr CDDNode) -> CInt -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_CheckZeroRef"
     c_cuddCheckZeroRef :: Ptr CDDManager -> IO CInt
@@ -323,13 +323,13 @@ foreign import ccall safe "Cudd_bddPermute_s"
     c_cuddBddPermute :: Ptr CDDManager -> Ptr CDDNode -> Ptr CInt -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_Xgty_s"
-	c_cuddXgty :: Ptr CDDManager -> CInt -> Ptr (Ptr CDDNode) -> Ptr (Ptr CDDNode) -> Ptr (Ptr CDDNode) -> IO (Ptr CDDNode)
+    c_cuddXgty :: Ptr CDDManager -> CInt -> Ptr (Ptr CDDNode) -> Ptr (Ptr CDDNode) -> Ptr (Ptr CDDNode) -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_Inequality_s"
-	c_cuddInequality :: Ptr CDDManager -> CInt -> CInt -> Ptr (Ptr CDDNode) -> Ptr (Ptr CDDNode) -> IO (Ptr CDDNode)
+    c_cuddInequality :: Ptr CDDManager -> CInt -> CInt -> Ptr (Ptr CDDNode) -> Ptr (Ptr CDDNode) -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_Disequality_s"
-	c_cuddDisequality :: Ptr CDDManager -> CInt -> CInt -> Ptr (Ptr CDDNode) -> Ptr (Ptr CDDNode) -> IO (Ptr CDDNode)
+    c_cuddDisequality :: Ptr CDDManager -> CInt -> CInt -> Ptr (Ptr CDDNode) -> Ptr (Ptr CDDNode) -> IO (Ptr CDDNode)
 
 foreign import ccall safe "Cudd_bddInterval_s"
     c_cuddBddInterval :: Ptr CDDManager -> CInt -> Ptr (Ptr CDDNode) -> CInt -> CInt -> IO (Ptr CDDNode)
@@ -341,13 +341,13 @@ foreign import ccall safe "Cudd_bddTransfer"
     c_cuddBddTransfer :: Ptr CDDManager -> Ptr CDDManager -> Ptr CDDNode -> IO (Ptr CDDNode)
 
 foreign import ccall safe "&Cudd_RecursiveDeref"
-	c_cuddRecursiveDerefPtr :: FunPtr (Ptr CDDManager -> Ptr CDDNode -> IO ())
+    c_cuddRecursiveDerefPtr :: FunPtr (Ptr CDDManager -> Ptr CDDNode -> IO ())
 
 foreign import ccall safe "&Cudd_DelayedDerefBdd"
-	c_cuddDelayedDerefBddPtr :: FunPtr (Ptr CDDManager -> Ptr CDDNode -> IO ())
+    c_cuddDelayedDerefBddPtr :: FunPtr (Ptr CDDManager -> Ptr CDDNode -> IO ())
 
 foreign import ccall safe "&Cudd_IterDerefBdd"
-	c_cuddIterDerefBddPtr :: FunPtr (Ptr CDDManager -> Ptr CDDNode -> IO ())
+    c_cuddIterDerefBddPtr :: FunPtr (Ptr CDDManager -> Ptr CDDNode -> IO ())
 
 foreign import ccall safe "Cudd_bddNewVar_s"
     c_cuddBddNewVar :: Ptr CDDManager -> IO (Ptr CDDNode)

--- a/Cudd/Cudd.hs
+++ b/Cudd/Cudd.hs
@@ -125,24 +125,24 @@ cuddArg0 f (DDManager m) = DDNode $ unsafePerformIO $ do
 
 cuddArg1 :: (Ptr CDDManager -> Ptr CDDNode -> IO (Ptr CDDNode)) -> DDManager -> DDNode -> DDNode
 cuddArg1 f (DDManager m) (DDNode x) = DDNode $ unsafePerformIO $ 
-	withForeignPtr x $ \xp -> do
-	node <- f m xp
-	newForeignPtrEnv deref m node
+    withForeignPtr x $ \xp -> do
+    node <- f m xp
+    newForeignPtrEnv deref m node
 
 cuddArg2 :: (Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)) -> DDManager -> DDNode -> DDNode -> DDNode
 cuddArg2 f (DDManager m) (DDNode l) (DDNode r) = DDNode $ unsafePerformIO $ 
- 	withForeignPtr l $ \lp -> 
-	withForeignPtr r $ \rp -> do
-	node <- f m lp rp
-	newForeignPtrEnv deref m node
+    withForeignPtr l $ \lp -> 
+    withForeignPtr r $ \rp -> do
+    node <- f m lp rp
+    newForeignPtrEnv deref m node
 
 cuddArg3 :: (Ptr CDDManager -> Ptr CDDNode -> Ptr CDDNode -> Ptr CDDNode -> IO (Ptr CDDNode)) -> DDManager -> DDNode -> DDNode-> DDNode -> DDNode
 cuddArg3 f (DDManager m) (DDNode l) (DDNode r) (DDNode x) = DDNode $ unsafePerformIO $ 
- 	withForeignPtr l $ \lp -> 
-	withForeignPtr r $ \rp -> 
-	withForeignPtr x $ \xp -> do
-	node <- f m lp rp xp
-	newForeignPtrEnv deref m node
+    withForeignPtr l $ \lp -> 
+    withForeignPtr r $ \rp -> 
+    withForeignPtr x $ \xp -> do
+    node <- f m lp rp xp
+    newForeignPtrEnv deref m node
 
 readOne :: DDManager -> DDNode
 readOne = cuddArg0 c_cuddReadOneWithRef
@@ -254,7 +254,7 @@ readSize (DDManager m) = fromIntegral $ unsafePerformIO $ c_cuddReadSize m
 
 supportIndex :: DDManager -> DDNode -> [Bool]
 supportIndex (DDManager m) (DDNode n) = unsafePerformIO $ 
-	withForeignPtr n $ \np -> do
+    withForeignPtr n $ \np -> do
     res <- c_cuddSupportIndex m np
     size <- c_cuddReadSize m
     res <- peekArray (fromIntegral size) res
@@ -341,12 +341,12 @@ minimize = cuddArg2 c_cuddBddMinimize
 
 pickOneMinterm :: DDManager -> DDNode -> [DDNode] -> Maybe DDNode
 pickOneMinterm (DDManager m) (DDNode d) vars = unsafePerformIO $
-	withForeignPtr d $ \dp -> 
-	withForeignArrayPtrLen (map unDDNode vars) $ \vs vp -> do
-	node <- c_cuddBddPickOneMinterm m dp vp (fromIntegral vs)
-	if node == nullPtr then return Nothing else do
-		nd <- newForeignPtrEnv deref m node
-		return $ Just $ DDNode nd
+    withForeignPtr d $ \dp -> 
+    withForeignArrayPtrLen (map unDDNode vars) $ \vs vp -> do
+    node <- c_cuddBddPickOneMinterm m dp vp (fromIntegral vs)
+    if node == nullPtr then return Nothing else do
+        nd <- newForeignPtrEnv deref m node
+        return $ Just $ DDNode nd
 
 printInfo :: DDManager -> Ptr CFile -> IO Int
 printInfo (DDManager m) cf = liftM fromIntegral $ c_cuddPrintInfo m cf

--- a/Cudd/GC.hs
+++ b/Cudd/GC.hs
@@ -25,28 +25,28 @@ import Cudd.C
 import Cudd.Imperative
 
 foreign import ccall safe "Cudd_EnableGarbageCollection"
-	c_cuddEnableGarbageCollection :: Ptr CDDManager -> IO ()
+    c_cuddEnableGarbageCollection :: Ptr CDDManager -> IO ()
 
 cuddEnableGarbageCollection :: DDManager s u -> ST s ()
 cuddEnableGarbageCollection (DDManager m) = unsafeIOToST $ c_cuddEnableGarbageCollection m
 
 foreign import ccall safe "Cudd_DisableGarbageCollection"
-	c_cuddDisableGarbageCollection :: Ptr CDDManager -> IO ()
+    c_cuddDisableGarbageCollection :: Ptr CDDManager -> IO ()
 
 cuddDisableGarbageCollection :: DDManager s u -> ST s ()
 cuddDisableGarbageCollection (DDManager m) = unsafeIOToST $ c_cuddDisableGarbageCollection m
 
 foreign import ccall safe "Cudd_GarbageCollectionEnabled"
-	c_cuddGarbageCollectionEnabled :: Ptr CDDManager -> IO CInt
+    c_cuddGarbageCollectionEnabled :: Ptr CDDManager -> IO CInt
 
 cuddGarbageCollectionEnabled :: DDManager s u -> ST s Int
 cuddGarbageCollectionEnabled (DDManager m) = unsafeIOToST $ liftM fromIntegral $ c_cuddGarbageCollectionEnabled m
 
 foreign import ccall safe "&preGCHook_sample"
-	c_preGCHook_sample :: HookFP
+    c_preGCHook_sample :: HookFP
 
 foreign import ccall safe "&postGCHook_sample"
-	c_postGCHook_sample :: HookFP
+    c_postGCHook_sample :: HookFP
 
 regPreGCHook :: DDManager s u -> HookFP -> ST s Int
 regPreGCHook m func = cuddAddHook m func CuddPreGcHook

--- a/Cudd/Hook.chs
+++ b/Cudd/Hook.chs
@@ -30,13 +30,13 @@ type HookTyp = Ptr CDDManager -> CString -> Ptr () -> IO (CInt)
 type HookFP  = FunPtr HookTyp
 
 foreign import ccall safe "Cudd_AddHook"
-	c_cuddAddHook :: Ptr CDDManager -> HookFP -> CInt -> IO (CInt)
+    c_cuddAddHook :: Ptr CDDManager -> HookFP -> CInt -> IO (CInt)
 
 cuddAddHook :: DDManager s u -> HookFP -> CuddHookType -> ST s Int
 cuddAddHook (DDManager m) fp typ = unsafeIOToST $ liftM fromIntegral $ c_cuddAddHook m fp (fromIntegral $ fromEnum typ)
-	
+
 foreign import ccall safe "Cudd_RemoveHook"
-	c_cuddRemoveHook :: Ptr CDDManager -> HookFP -> CInt -> IO (CInt)
+    c_cuddRemoveHook :: Ptr CDDManager -> HookFP -> CInt -> IO (CInt)
 
 cuddRemoveHook :: DDManager s u -> HookFP -> CuddHookType -> ST s Int
 cuddRemoveHook (DDManager m) fp typ = unsafeIOToST $ liftM fromIntegral $ c_cuddRemoveHook m fp (fromIntegral $ fromEnum typ)

--- a/Cudd/Reorder.chs
+++ b/Cudd/Reorder.chs
@@ -69,37 +69,37 @@ setFloat f (DDManager m) v = unsafeIOToST $ f m (realToFrac v)
 
 --Reorder when needed
 foreign import ccall safe "Cudd_ReorderingStatus"
-	c_cuddReorderingStatus :: Ptr CDDManager -> Ptr CInt -> IO (CInt)
+    c_cuddReorderingStatus :: Ptr CDDManager -> Ptr CInt -> IO (CInt)
 
 cuddReorderingStatus :: DDManager s u -> ST s (Int, CuddReorderingType)
 cuddReorderingStatus (DDManager m) = unsafeIOToST $ do
-	alloca $ \mem -> do
-		res <- c_cuddReorderingStatus m mem
-		typ <- peek mem
-		return $ (fromIntegral res, toEnum $ fromIntegral typ)
+    alloca $ \mem -> do
+        res <- c_cuddReorderingStatus m mem
+        typ <- peek mem
+        return $ (fromIntegral res, toEnum $ fromIntegral typ)
 
 foreign import ccall safe "Cudd_AutodynEnable"
-	c_cuddAutodynEnable :: Ptr CDDManager -> CInt -> IO ()
+    c_cuddAutodynEnable :: Ptr CDDManager -> CInt -> IO ()
 
 cuddAutodynEnable :: DDManager s u -> CuddReorderingType -> ST s ()
 cuddAutodynEnable (DDManager m) t = unsafeIOToST $ c_cuddAutodynEnable m (fromIntegral $ fromEnum t)
 
 foreign import ccall safe "Cudd_AutodynDisable"
-	c_cuddAutodynDisable :: Ptr CDDManager -> IO ()
+    c_cuddAutodynDisable :: Ptr CDDManager -> IO ()
 
 cuddAutodynDisable :: DDManager s u -> ST s ()
 cuddAutodynDisable (DDManager m) = unsafeIOToST $ c_cuddAutodynDisable m
 
 --Reorder right now
 foreign import ccall safe "Cudd_ReduceHeap"
-	c_cuddReduceHeap :: Ptr CDDManager -> CInt -> CInt -> IO (CInt)
+    c_cuddReduceHeap :: Ptr CDDManager -> CInt -> CInt -> IO (CInt)
 
 cuddReduceHeap :: DDManager s u -> CuddReorderingType -> Int -> ST s Int
 cuddReduceHeap (DDManager m) typ minsize = unsafeIOToST $ liftM fromIntegral $ c_cuddReduceHeap m (fromIntegral $ fromEnum typ) (fromIntegral minsize)
 
 --Grouping
 foreign import ccall safe "Cudd_MakeTreeNode"
-	c_cuddMakeTreeNode :: Ptr CDDManager -> CUInt -> CUInt -> CUInt -> IO (Ptr ())
+    c_cuddMakeTreeNode :: Ptr CDDManager -> CUInt -> CUInt -> CUInt -> IO (Ptr ())
 
 cuddMakeTreeNode :: DDManager s u -> Int -> Int -> Int -> ST s (Ptr ())
 cuddMakeTreeNode (DDManager m) low size typ = unsafeIOToST $ do
@@ -109,38 +109,38 @@ cuddMakeTreeNode (DDManager m) low size typ = unsafeIOToST $ do
 
 --Reordering stats
 foreign import ccall safe "Cudd_ReadReorderingTime"
-	c_cuddReadReorderingTime :: Ptr CDDManager -> IO (CLong)
+    c_cuddReadReorderingTime :: Ptr CDDManager -> IO (CLong)
 
 cuddReadReorderingTime :: DDManager s u -> ST s Int
 cuddReadReorderingTime = readIntegral c_cuddReadReorderingTime
 
 foreign import ccall safe "Cudd_ReadReorderings"
-	c_cuddReadReorderings :: Ptr CDDManager -> IO (CUInt)
+    c_cuddReadReorderings :: Ptr CDDManager -> IO (CUInt)
 
 cuddReadReorderings :: DDManager s u -> ST s Int
 cuddReadReorderings = readIntegral c_cuddReadReorderings
 
 --Hooks
 foreign import ccall safe "&Cudd_StdPreReordHook"
-	c_cuddStdPreReordHook :: HookFP
+    c_cuddStdPreReordHook :: HookFP
 
 foreign import ccall safe "&Cudd_StdPostReordHook"
-	c_cuddStdPostReordHook :: HookFP
+    c_cuddStdPostReordHook :: HookFP
 
 foreign import ccall safe "Cudd_EnableReorderingReporting"
-	c_cuddEnableReorderingReporting :: Ptr CDDManager -> IO (CInt)
+    c_cuddEnableReorderingReporting :: Ptr CDDManager -> IO (CInt)
 
 cuddEnableReorderingReporting :: DDManager s u -> ST s Int
 cuddEnableReorderingReporting (DDManager m) = unsafeIOToST $ liftM fromIntegral $ c_cuddEnableReorderingReporting m
 
 foreign import ccall safe "Cudd_DisableReorderingReporting"
-	c_cuddDisableReorderingReporting :: Ptr CDDManager -> IO (CInt)
+    c_cuddDisableReorderingReporting :: Ptr CDDManager -> IO (CInt)
 
 cuddDisableReorderingReporting :: DDManager s u -> ST s Int
 cuddDisableReorderingReporting (DDManager m) = unsafeIOToST $ liftM fromIntegral $ c_cuddDisableReorderingReporting m
 
 foreign import ccall safe "Cudd_ReorderingReporting"
-	c_cuddReorderingReporting :: Ptr CDDManager -> IO (CInt)
+    c_cuddReorderingReporting :: Ptr CDDManager -> IO (CInt)
 
 cuddReorderingReporting :: DDManager s u -> ST s Int
 cuddReorderingReporting (DDManager m) = unsafeIOToST $ liftM fromIntegral $ c_cuddReorderingReporting m
@@ -153,117 +153,117 @@ regStdPostReordHook m = cuddAddHook m c_cuddStdPostReordHook CuddPostReorderingH
 
 --Universal reordering params
 foreign import ccall safe "Cudd_TurnOffCountDead"
-	c_cuddTurnOffCountDead :: Ptr CDDManager -> IO ()
+    c_cuddTurnOffCountDead :: Ptr CDDManager -> IO ()
 
 cuddTurnOffCountDead :: DDManager s u -> ST s ()
 cuddTurnOffCountDead (DDManager m) = unsafeIOToST $ c_cuddTurnOffCountDead m
 
 foreign import ccall safe "Cudd_TurnOnCountDead"
-	c_cuddTurnOnCountDead :: Ptr CDDManager -> IO ()
+    c_cuddTurnOnCountDead :: Ptr CDDManager -> IO ()
 
 cuddTurnOnCountDead :: DDManager s u -> ST s ()
 cuddTurnOnCountDead (DDManager m) = unsafeIOToST $ c_cuddTurnOnCountDead m
 
 foreign import ccall safe "Cudd_DeadAreCounted"
-	c_cuddDeadAreCounted :: Ptr CDDManager -> IO CInt
+    c_cuddDeadAreCounted :: Ptr CDDManager -> IO CInt
 
 cuddDeadAreCounted :: DDManager s u -> ST s Int
 cuddDeadAreCounted (DDManager m) = unsafeIOToST $ liftM fromIntegral $ c_cuddDeadAreCounted m
 
 --Sifting parameters
 foreign import ccall safe "Cudd_ReadSiftMaxSwap"
-	c_cuddReadSiftMaxSwap :: Ptr CDDManager -> IO (CInt)
+    c_cuddReadSiftMaxSwap :: Ptr CDDManager -> IO (CInt)
 
 cuddReadSiftMaxSwap :: DDManager s u -> ST s Int
 cuddReadSiftMaxSwap = readIntegral c_cuddReadSiftMaxSwap
 
 foreign import ccall safe "Cudd_SetSiftMaxSwap"
-	c_cuddSetSiftMaxSwap :: Ptr CDDManager -> CInt -> IO ()
+    c_cuddSetSiftMaxSwap :: Ptr CDDManager -> CInt -> IO ()
 
 cuddSetSiftMaxSwap :: DDManager s u -> Int -> ST s ()
 cuddSetSiftMaxSwap = setIntegral c_cuddSetSiftMaxSwap 
 
 foreign import ccall safe "Cudd_ReadSiftMaxVar"
-	c_cuddReadSiftMaxVar :: Ptr CDDManager -> IO (Int)
+    c_cuddReadSiftMaxVar :: Ptr CDDManager -> IO (Int)
 
 cuddReadSiftMaxVar :: DDManager s u -> ST s Int
 cuddReadSiftMaxVar = readIntegral c_cuddReadSiftMaxVar
 
 foreign import ccall safe "Cudd_SetSiftMaxVar"
-	c_cuddSetSiftMaxVar :: Ptr CDDManager -> CInt -> IO ()
+    c_cuddSetSiftMaxVar :: Ptr CDDManager -> CInt -> IO ()
 
 cuddSetSiftMaxVar :: DDManager s u -> Int -> ST s ()
 cuddSetSiftMaxVar = setIntegral c_cuddSetSiftMaxVar
-	
+    
 foreign import ccall safe "Cudd_ReadNextReordering"
-	c_cuddReadNextReordering :: Ptr CDDManager -> IO (Int)
+    c_cuddReadNextReordering :: Ptr CDDManager -> IO (Int)
 
 cuddReadNextReordering :: DDManager s u -> ST s Int
 cuddReadNextReordering = readIntegral c_cuddReadNextReordering
 
 foreign import ccall safe "Cudd_SetNextReordering"
-	c_cuddSetNextReordering :: Ptr CDDManager -> CInt -> IO ()
+    c_cuddSetNextReordering :: Ptr CDDManager -> CInt -> IO ()
 
 cuddSetNextReordering :: DDManager s u -> Int -> ST s ()
 cuddSetNextReordering = setIntegral c_cuddSetNextReordering
 
 foreign import ccall safe "Cudd_ReadMaxGrowthAlternate"
-	c_cuddReadMaxGrowthAlternate :: Ptr CDDManager -> IO CDouble
+    c_cuddReadMaxGrowthAlternate :: Ptr CDDManager -> IO CDouble
 
 cuddReadMaxGrowthAlternate :: DDManager s u -> ST s Double
 cuddReadMaxGrowthAlternate = readFloat c_cuddReadMaxGrowthAlternate
 
 foreign import ccall safe "Cudd_SetMaxGrowthAlternate"
-	c_cuddSetMaxGrowthAlternate :: Ptr CDDManager -> CDouble -> IO ()
+    c_cuddSetMaxGrowthAlternate :: Ptr CDDManager -> CDouble -> IO ()
 
 cuddSetMaxGrowthAlternate :: DDManager s u -> Double -> ST s ()
 cuddSetMaxGrowthAlternate = setFloat c_cuddSetMaxGrowthAlternate
 
 foreign import ccall safe "Cudd_ReadMaxGrowth"
-	c_cuddReadMaxGrowth :: Ptr CDDManager -> IO CDouble
+    c_cuddReadMaxGrowth :: Ptr CDDManager -> IO CDouble
 
 cuddReadMaxGrowth :: DDManager s u -> ST s Double
 cuddReadMaxGrowth = readFloat c_cuddReadMaxGrowth
 
 foreign import ccall safe "Cudd_SetMaxGrowth"
-	c_cuddSetMaxGrowth :: Ptr CDDManager -> CDouble -> IO ()
+    c_cuddSetMaxGrowth :: Ptr CDDManager -> CDouble -> IO ()
 
 cuddSetMaxGrowth :: DDManager s u -> Double -> ST s ()
 cuddSetMaxGrowth = setFloat c_cuddSetMaxGrowth
 
 foreign import ccall safe "Cudd_ReadReorderingCycle"
-	c_cuddReadReorderingCycle :: Ptr CDDManager -> IO (CInt)
+    c_cuddReadReorderingCycle :: Ptr CDDManager -> IO (CInt)
 
 cuddReadReorderingCycle :: DDManager s u -> ST s Int
 cuddReadReorderingCycle = readIntegral c_cuddReadReorderingCycle
 
 foreign import ccall safe "Cudd_SetReorderingCycle"
-	c_cuddSetReorderingCycle :: Ptr CDDManager -> CInt -> IO ()
+    c_cuddSetReorderingCycle :: Ptr CDDManager -> CInt -> IO ()
 
 cuddSetReorderingCycle :: DDManager s u -> Int -> ST s ()
 cuddSetReorderingCycle = setIntegral c_cuddSetReorderingCycle
 
 --Genetic algorithm
 foreign import ccall safe "Cudd_ReadPopulationSize"
-	c_cuddReadPopulationSize :: Ptr CDDManager -> IO (CInt)
+    c_cuddReadPopulationSize :: Ptr CDDManager -> IO (CInt)
 
 cuddReadPopulationSize :: DDManager s u -> ST s Int
 cuddReadPopulationSize = readIntegral c_cuddReadPopulationSize
 
 foreign import ccall safe "Cudd_SetPopulationSize"
-	c_cuddSetPopulationSize :: Ptr CDDManager -> CInt -> IO ()
+    c_cuddSetPopulationSize :: Ptr CDDManager -> CInt -> IO ()
 
 cuddSetPopulationSize :: DDManager s u -> Int -> ST s ()
 cuddSetPopulationSize = setIntegral c_cuddSetPopulationSize
 
 foreign import ccall safe "Cudd_ReadNumberXovers"
-	c_cuddReadNumberXovers :: Ptr CDDManager -> IO (CInt)
+    c_cuddReadNumberXovers :: Ptr CDDManager -> IO (CInt)
 
 cuddReadNumberXovers :: DDManager s u -> ST s Int
 cuddReadNumberXovers = readIntegral c_cuddReadNumberXovers
 
 foreign import ccall safe "Cudd_SetNumberXovers"
-	c_cuddSetNumberXovers :: Ptr CDDManager -> CInt -> IO ()
+    c_cuddSetNumberXovers :: Ptr CDDManager -> CInt -> IO ()
 
 cuddSetNumberXovers :: DDManager s u -> Int -> ST s ()
 cuddSetNumberXovers = setIntegral c_cuddSetNumberXovers


### PR DESCRIPTION
How about replacing tab characters with spaces?

Recent GHC warns tab character usage [-Wtabs]. E.g.

```
haskell_cudd/Cudd/C.hs:116:1: warning: [-Wtabs]
    Tab character found here, and in 27 further locations.
    Please use spaces instead.
    |
116 |         c_cuddReadOne :: Ptr CDDManager -> IO (Ptr CDDNode)
    | ^^^^^^^^
```